### PR TITLE
Ensure all struct members are cleared after construction

### DIFF
--- a/src/YM7128B_emu.c
+++ b/src/YM7128B_emu.c
@@ -28,6 +28,8 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "YM7128B_emu.h"
 
+#include <assert.h>
+
 // ============================================================================
 
 char const* YM7128B_GetVersion(void)
@@ -660,7 +662,7 @@ void YM7128B_ChipFixed_Write(
 
 void YM7128B_ChipFloat_Ctor(YM7128B_ChipFloat* self)
 {
-    (void)self;
+    YM7128B_ChipFloat_Reset(self);
 }
 
 // ----------------------------------------------------------------------------
@@ -674,9 +676,22 @@ void YM7128B_ChipFloat_Dtor(YM7128B_ChipFloat* self)
 
 void YM7128B_ChipFloat_Reset(YM7128B_ChipFloat* self)
 {
-    for (YM7128B_Address i = 0; i <= YM7128B_Address_Max; ++i) {
+    assert(self);
+
+    for (int i = 0; i < YM7128B_Reg_Count; ++i)
         self->regs_[i] = 0;
-    }
+
+    for (int i = 0; i < YM7128B_Reg_T0; ++i)
+        self->gains_[i] = 0.0f;
+
+    self->t0_d_ = 0.0f;
+    self->tail_ = 0;
+
+    for (int i = 0; i < YM7128B_Buffer_Length; ++i)
+        self->buffer_[i] = 0.0f;
+
+    for (int i = 0; i < YM7128B_OutputChannel_Count; ++i)
+        YM7128B_OversamplerFloat_Clear(&self->oversampler_[i], 0.0f);
 }
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes an issue where uninitialized values were being used in calculations, leading to unstable results:

``` text
#7  0x0000555555966a44 in AdlibGold::Process (this=0x55555f0ba0c0, 
    in=0x7fffffff7b70, frames=49, out=0x7fffffff5ba0)
    at ../../src/hardware/adlib_gold.cpp:418
        frame = {left = -18, right = -18}
        wet = {left = -1.4818116e-22, right = -inf}
        wet_boost = 1.60000002
        frames_remaining = 36
#8  0x0000555555962a42 in NukedOPL::Handler::Generate (this=0x55555f0c0dd0, chan=warning: RTTI symbol not found for class 'std::_Sp_counted_ptr_inplace<MixerChannel, std::allocator<MixerChannel>, (__gnu_cxx::_Lock_policy)2>'
warning: RTTI symbol not found for class 'std::_Sp_counted_ptr_inplace<MixerChannel, std::allocator<MixerChannel>, (__gnu_cxx::_Lock_policy)2>'

    std::shared_ptr<MixerChannel> (use count 2, weak count 0) = {...}, frames=49)
    at ../../src/hardware/adlib.cpp:223
        todo = 49
        buf = {-18 <repeats 100 times>, 31958, -1, 32767, 0, 31952, -1, 32767, 0, 
          5520, 24274, 21845, 0, 31951, -1, 32767, 0, 31952, -1, 32767, 0, 31958, 
          -1, 32767, 0, 5520, 24274, 21845, 0, 31888, -1, 32767, 0, -25796, 21910, 
          21845, 0, 6656, 22814, 21845, 0, 5520, 24274, 21845, 0, 31958, -1, 32767, 
          0, 31952, -1, 32767, 0, 31951, -1, 32767, 0, 31952, -1, 32767, 0, 31958, 
          -1, 32767, 0, 5520, 24274, 21845, 0, 31968, -1, 32767, 0, 22386, 21914, 
          21845, 0, 5520, 24274, 21845, 0, 31958, -1, 32767, 0, 31952, -1, 32767, 0, 
          -25888, 21910, 21845, 0, 5520, 24274, 21845, 0, 22236, 21914, 21845, 256, 
          63, 0, 21845, 969, 5520, 24274, 21845, 0, 32032, -1, 32767, 0, 19589, 
          21914, 21845, 0, 0, 0, 0, 0, 32016, -1, 32767, 0, 32008, -1, 32767, 0, 
          5504, 24274, 21845, 0, 0, 512, 0, 512, 0, 8, 16128, 969, 32112, -1, 32767, 
          0, 11974, 21914, 21845, 0, 32080, -1, 32767, 0, 7917, 21870, 21845, 0, 0, 
          16, -32768, 14387, 15019, 22817, 21845, 0, 32112, -1, 32767, 0, 289, 
          21870, 21845, 0, 0, 22816, 21845, 0, 15019, 1, 0, 11776, 32240, -1, 32767, 
          0, 2624, 21870, 21845, 0, 5, 0...}
        float_buf = {-320.218719, -320.218719, -320.228088, -320.228088, 
          -320.237366, -320.237366, -320.24646, -320.24646, -320.255463, 
          -320.255463, -320.264313, -320.264313, -320.273071, -320.273071, 
          -320.281677, -320.281677, -320.290131, -320.290131, -320.298462, 
          -320.298462, -320.306702, -320.306702, -320.314758, -320.314758, 
          -319.750092, -319.750092, -319.766418, -319.766418, -319.782593, 
          -319.782593, -319.798462, -319.798462, -319.814117, -319.814117, 
          -319.829559, -319.829559, -319.844727, -319.844727, -319.85968, 
          -319.85968, -319.874451, -319.874451, -319.888977, -319.888977, 
          -319.90332, -319.90332, -319.917419, -319.917419, -319.931305, 
          -319.931305, -319.945007, -319.945007, -319.958405, -319.958405, 
--Type <RET> for more, q to quit, c to continue without paging--
          -319.971741, -319.971741, -319.984802, -319.984802, -319.997711, 
          -319.997711, -320.010437, -320.010437, -320.022858, -320.022858, 
          -320.035217, -320.035217, -320.047333, -320.047333, -320.059326, 
          -320.059326, -320.071106, -320.071106, -320.082764, -320.082764, 
          -320.094116, -320.094116, -320.105347, -320.105347, -320.116516, 
          -320.116516, -320.12738, -320.12738, -320.138184, -320.138184, 
          -320.148773, -320.148773, -320.15921, -320.15921, -320.169525, 
          -320.169525, -320.179626, -320.179626, -320.189606, -320.189606, 
          -320.199463, -320.199463, -320.209137, -320.209137, -308.901245, 
          -308.901245, -2.35435047e+38 <repeats 18 times>, -3.28882355e+38, 
          -4.20001089e-10, 0, 0, 0, 0, 0, 0, 0, 0, -3.59518702e-34, -9.60536991e+37, 
          -2.35435047e+38 <repeats 27 times>, -2.71960117e+38, -1.7144443e+38, 
          -1.7144443e+38, -1.7144443e+38, -1.7144443e+38, -5.02995216e+33, 0, 
          1.09288993e+19, 0, -1.7144443e+38, -1.7144443e+38, -1.7144443e+38, 
          -1.7144443e+38, -5.86066564e+33, 0, -nan(0x7f63b0), 0, 0, 0, 
          2.88478357e+13, 0, -5.02995216e+33, 0, 1.09274391e+19, 0, -4.99963687e+33, 
          0, -2.99581919e+38, -2.98247479e+38, -5.86066564e+33, 0, -nan(0x7f63f0), 
          0, 0, 0, 2.88478357e+13, 0, 0, 0, 2.88478336e+13, 0, -4.99963687e+33, 0, 
          0, -nan(0x72f2f2), 2.88478001e+13, 0, 0, 0, -nan(0x7f8610), 0, 
          -nan(0x7f8530), 0, 0, 0, 0, 0, 0, 0, 0, -nan(0x7fffff), -1.90157792e+38, 
          0, 0, -nan(0x72f2f2), 0, 0, -5.87262909e+33...}
        remaining = 49
#9  0x0000555555960712 in OPL_CallBack (len=49) at ../../src/hardware/adlib.cpp:820
No locals.
```